### PR TITLE
Fix buildifier issue with unused variable 'repo_mapping'

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,4 +1,8 @@
 """Dependency specific initialization."""
 
-def deps(repo_mapping = {}):
+# We use '_repo_mapping' with underscore as the parameter
+# in the 'deps()' function to avoid buildifier's warning
+# about using unused variable 'repo_mapping'.
+# https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#variable-is-unused
+def deps(_repo_mapping = {}):
     pass


### PR DESCRIPTION
This PR was inspired by the following [check](https://github.com/3rdparty/stout/runs/6060415636?check_suite_focus=true) failed in [#23](https://github.com/3rdparty/stout/pull/23).